### PR TITLE
Fix for #1721 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * [#1710](https://github.com/ruby-grape/grape/pull/1710): Fix wrong transformation of empty Array in declared params - [@pablonahuelgomez](https://github.com/pablonahuelgomez).
+* [#1722](https://github.com/ruby-grape/grape/pull/1722): Fix catch-all hiding multiple versions of an endpoint after the first definition - [@zherr](https://github.com/zherr).
 * Your contribution here.
 
 ### 1.0.1 (9/8/2017)

--- a/lib/grape/router.rb
+++ b/lib/grape/router.rb
@@ -103,6 +103,8 @@ module Grape
         neighbor.endpoint
       ) if neighbor && method == 'OPTIONS' && !cascade
 
+      return neighbor.endpoint.call(env) if neighbor && cascade && match?(input, '*')
+
       route = match?(input, '*')
       if route
         response = process_route(route, env)


### PR DESCRIPTION
Fix for #1721 - Defining a catch-all after multiple versions of an endpoint hide endpoints after the first definition

@dblock Let me know if you have any questions/comments/concerns on this one. Thanks!